### PR TITLE
[35기 오창훈] Add: Buttons 컴포넌트 레이아웃 및 기능 구현

### DIFF
--- a/src/components/Buttons/Buttons.js
+++ b/src/components/Buttons/Buttons.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { FaAngleDoubleLeft } from 'react-icons/fa';
+import { FaAngleDoubleRight } from 'react-icons/fa';
+import './Buttons.scss';
+
+export default function Buttons({ updateOffset, totalItems }) {
+  const buttonMaker = () => {
+    const result = [];
+
+    result.push(
+      <button className="pageBtn" onClick={() => updateOffset(1)}>
+        <FaAngleDoubleLeft />
+      </button>
+    );
+
+    for (let i = 0; i < Math.ceil(totalItems / 12); i++) {
+      result.push(
+        <button className="pageBtn nums" onClick={() => updateOffset(i + 1)}>
+          {i + 1}
+        </button>
+      );
+    }
+
+    result.push(
+      <button
+        className="pageBtn"
+        onClick={() => updateOffset(Math.ceil(totalItems / 12))}
+      >
+        <FaAngleDoubleRight />
+      </button>
+    );
+
+    return result;
+  };
+  return <div className="pageBtnWrapper">{buttonMaker()}</div>;
+}

--- a/src/components/Buttons/Buttons.scss
+++ b/src/components/Buttons/Buttons.scss
@@ -1,0 +1,21 @@
+.pageBtnWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin: 30px 0;
+
+  .pageBtn {
+    width: 34px;
+    height: 40px;
+    text-align: center;
+    line-height: 40px;
+    color: #8e8e8e;
+    background-color: inherit;
+    border: 1px solid #dbdbdb;
+    border-radius: 1px;
+  }
+
+  .nums {
+    color: #333333;
+  }
+}


### PR DESCRIPTION
## :: 최근 작업 주제
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 보여줘야 할 데이터의 양에 맞게 페이지 선택 버튼의 갯수 조절

<br />

## :: 구현 사항 설명
buttonMaker라는 함수를 정의하고 사용하는데,
이 함수는 props로
    쿼리 파라미터를 생성하고 navigate하는 updateOffset 함수와
    productList에서 보여줘야 할 아이템들의 총 개수를 담고 있는 totalItems 변수를 받는다.

해당 함수로 인해 버튼은 총 2+n개가 만들어지는데,
2개는 첫 페이지와 마지막 페이지로 이동하는 버튼이고, n개는 유동적으로 그 갯수가 변한다.

마지막 페이지의 계산은 Math.ceil(totalItems / 12)를 통해 계산한다.
```
const buttonMaker = () => {
  const result = [];

  result.push(
    <button className="pageBtn" onClick={() => updateOffset(1)}>
      <FaAngleDoubleLeft />
    </button>
  );

  for (let i = 0; i < Math.ceil(totalItems / 12); i++) {
    result.push(
      <button className="pageBtn nums" onClick={() => updateOffset(i + 1)}>
        {i + 1}
      </button>
    );
  }

  result.push(
    <button
      className="pageBtn"
      onClick={() => updateOffset(Math.ceil(totalItems / 12))}
    >
      <FaAngleDoubleRight />
    </button>
  );

  return result;
};
```

<br />